### PR TITLE
prf: remove small statistical bias in PRF output and speedup

### DIFF
--- a/src/symmetric/prf/shake_to_field.rs
+++ b/src/symmetric/prf/shake_to_field.rs
@@ -8,6 +8,9 @@ use sha3::{
     digest::{ExtendableOutput, Update, XofReader},
 };
 
+/// Number of pseudorandom bytes to generate one pseudorandom field element
+const PRF_BYTES_PER_FE: usize = 16;
+
 const KEY_LENGTH: usize = 32; // 32 bytes
 const PRF_DOMAIN_SEP: [u8; 16] = [
     0xae, 0xae, 0x22, 0xff, 0x00, 0x01, 0xfa, 0xff, 0x21, 0xaf, 0x12, 0x00, 0x01, 0x11, 0xff, 0x00,
@@ -59,13 +62,13 @@ where
         // Mapping bytes to field elements
         std::array::from_fn(|_| {
             // Buffer to store the output
-            let mut buf = [0u8; 8];
+            let mut buf = [0u8; PRF_BYTES_PER_FE];
 
             // Read the extended output into the buffer
             xof_reader.read(&mut buf);
 
             // Mapping bytes to a field element
-            F::from_u64(u64::from_be_bytes(buf))
+            F::from_u128(u128::from_be_bytes(buf))
         })
     }
 
@@ -103,13 +106,13 @@ where
         // Mapping bytes to field elements
         std::array::from_fn(|_| {
             // Buffer to store the output
-            let mut buf = [0u8; 8];
+            let mut buf = [0u8; PRF_BYTES_PER_FE];
 
             // Read the extended output into the buffer
             xof_reader.read(&mut buf);
 
             // Mapping bytes to a field element
-            F::from_u64(u64::from_be_bytes(buf))
+            F::from_u128(u128::from_be_bytes(buf))
         })
     }
 


### PR DESCRIPTION
Related https://github.com/leanEthereum/leanSig/issues/10

We are switching to 128 bits and made an optimization by not relying on big integers but for now we keep the issue opened since we need more investigations to know if we will switch to 256 bits or not.

Benchmarks after this PR are:

```shell
Benchmarking Poseidon: Top Level TS, Lifetime 2^8, Activation 2^18, Dimension 64, Base 8/- gen: Warming up for 3Benchmarking Poseidon: Top Level TS, Lifetime 2^8, Activation 2^18, Dimension 64, Base 8/- gen: Collecting 10 saPoseidon: Top Level TS, Lifetime 2^8, Activation 2^18, Dimension 64, Base 8/- gen
                        time:   [6.4355 ms 6.6207 ms 6.8828 ms]
                        change: [−25.552% −22.650% −19.475%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking Poseidon: Top Level TS, Lifetime 2^8, Activation 2^18, Dimension 64, Base 8/- sign: Warming up for Benchmarking Poseidon: Top Level TS, Lifetime 2^8, Activation 2^18, Dimension 64, Base 8/- sign: Collecting 100 Poseidon: Top Level TS, Lifetime 2^8, Activation 2^18, Dimension 64, Base 8/- sign
                        time:   [639.38 µs 648.98 µs 658.74 µs]
                        change: [−5.0963% −2.9650% −0.8160%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
Benchmarking Poseidon: Top Level TS, Lifetime 2^8, Activation 2^18, Dimension 64, Base 8/- verify: Warming up foBenchmarking Poseidon: Top Level TS, Lifetime 2^8, Activation 2^18, Dimension 64, Base 8/- verify: Collecting 10Poseidon: Top Level TS, Lifetime 2^8, Activation 2^18, Dimension 64, Base 8/- verify
                        time:   [193.45 µs 194.40 µs 195.73 µs]
                        change: [+0.5447% +1.0625% +1.8188%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe
```

Even if we base from 64 bits to 128, it seems better because we don't rely anymore on big integers which are heavy due to vector allocations and heavy operations, so this is a good news that we increase security while improving performances.