### PR TITLE
encode FieldArray without size

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -359,4 +359,12 @@ mod tests {
         assert_ne!(arr1, arr3);
         assert_ne!(arr2, arr3);
     }
+
+    #[test]
+    fn test_bincode_no_size_prefix() {
+        let config = bincode::config::standard().with_fixed_int_encoding();
+        let arr = FieldArray([F::new(1), F::new(2), F::new(3)]);
+        let encoded = bincode::serde::encode_to_vec(arr, config).unwrap();
+        assert_eq!(encoded.len(), arr.len() * F::NUM_BYTES);
+    }
 }


### PR DESCRIPTION
- [Spec expects 3116 byte signature](https://github.com/leanEthereum/leanSpec/blob/22f2e44061b2919340f9399e49e1a89fa288ea59/src/lean_spec/subspecs/containers/signature.py#L12) (bincode).
  - actual size is 3884
- `FieldArray` used `collect_seq`/`deserialize_seq`, which encoded sequence size (extra bytes).
- `FieldArray` size is fixed, so use `serialize_tuple`/`deserialize_tuple`.