### PR TITLE
feat: dont infer const arguments

### DIFF
--- a/src/symmetric/tweak_hash/poseidon.rs
+++ b/src/symmetric/tweak_hash/poseidon.rs
@@ -540,7 +540,7 @@ impl<
 
                 // Apply the sponge hash to produce the leaf.
                 // This absorbs all chain ends and squeezes out the final hash.
-                let packed_leaves = poseidon_sponge::<PackedF, _, _, _>(
+                let packed_leaves = poseidon_sponge::<PackedF, _, MERGE_COMPRESSION_WIDTH, HASH_LEN>(
                     &sponge_perm,
                     &capacity_val,
                     &packed_leaf_input,


### PR DESCRIPTION
Essentially the solution proposed in https://github.com/leanEthereum/leanSig/issues/7
Changes

```
let packed_leaves = poseidon_sponge::<PackedF, _, _, _>
```
                                                                                            
to:

```
let packed_leaves = poseidon_sponge::<PackedF, _, MERGE_COMPRESSION_WIDTH, HASH_LEN>
```

This does not close https://github.com/leanEthereum/leanSig/issues/15 yet as I still get the following build error:

```
warning: build failed, waiting for other jobs to finish...
error: target is not supported, for more information see: https://docs.rs/getrandom/#unsupported-targets
   --> /Users/varundoshi/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/getrandom-0.2.16/src/lib.rs:351:9
    |
351 | /         compile_error!("target is not supported, for more information see: \
352 | |                         https://docs.rs/getrandom/#unsupported-targets");
    | |________________________________________________________________________^

error[E0433]: failed to resolve: use of unresolved module or unlinked crate `imp`
   --> /Users/varundoshi/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/getrandom-0.2.16/src/lib.rs:402:9
    |
402 |         imp::getrandom_inner(dest)?;
    |         ^^^ use of unresolved module or unlinked crate `imp`
    |
    = help: if you wanted to use a crate named `imp`, use `cargo add imp` to add it to your `Cargo.toml`

For more information about this error, try `rustc --explain E0433`.
error: could not compile `getrandom` (lib) due to 2 previous errors

```

This seems to be an issue with the `ring` crate being used.