### PR TITLE
add edition field to rustfmt.toml file

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
+edition = "2024"
 reorder_imports = true


### PR DESCRIPTION
This is important. Without this line, any invocation of `rustfmt` directly is going to read rustfmt.toml, but fall back to the default edition, which is 2015 (or was until recently). This causes the code to be formatted slightly differently from someone who runs `cargo fmt`. The latter looks up the edition from the Cargo.toml file.

In Emacs for example the standard way to use rustfmt is via the binary directly and *not* via Cargo. So any editor / tooling that works like Emacs will produce wrongly formatted code despite the fact that rustfmt is used.

@tcoratger This was the reason my code was wrongly formatted the other day in Plonky3. I think we should adopt this for the other repos as well.