### PR TITLE
feat: allow injecting Poseidon2 permutations (16/24)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,24 +52,26 @@ pub enum Poseidon2InitError {
 ///
 /// # Example
 /// ```no_run
-/// use leansig::init_poseidon2_24_with;
+/// use leansig::init_poseidon2_24;
+/// use p3_koala_bear::Poseidon2KoalaBear;
 ///
 /// // Build your custom Poseidon2(24) permutation here.
 /// // For example, from a spec-aligned constant set.
-/// init_poseidon2_24_with(|| {
-///     // ... construct Poseidon2KoalaBear<24> ...
-///     unimplemented!()
-/// }).unwrap();
+/// let perm: Poseidon2KoalaBear<24> = unimplemented!();
+/// init_poseidon2_24(perm).unwrap();
 /// ```
+///
+/// For a builder-style API, see [`init_poseidon2_24_with`].
 pub fn init_poseidon2_24(perm: Poseidon2KoalaBear<24>) -> Result<(), Poseidon2InitError> {
     POSEIDON2_24
         .set(perm)
         .map_err(|_| Poseidon2InitError::AlreadyInitialized { width: 24 })
 }
 
-/// Initialize the width-24 Poseidon2 permutation using a constructor.
+/// Initialize the width-24 Poseidon2 permutation using a builder.
 ///
-/// The constructor will only be called if the permutation has not been initialized yet.
+/// The builder is only called if the permutation has not been initialized yet.
+/// This function is intended for single-threaded initialization at program startup.
 ///
 /// # Errors
 /// Returns `Poseidon2InitError::AlreadyInitialized { width: 24 }` if the permutation was already
@@ -91,22 +93,24 @@ where
 ///
 /// # Example
 /// ```no_run
-/// use leansig::init_poseidon2_16_with;
+/// use leansig::init_poseidon2_16;
+/// use p3_koala_bear::Poseidon2KoalaBear;
 ///
-/// init_poseidon2_16_with(|| {
-///     // ... construct Poseidon2KoalaBear<16> ...
-///     unimplemented!()
-/// }).unwrap();
+/// let perm: Poseidon2KoalaBear<16> = unimplemented!();
+/// init_poseidon2_16(perm).unwrap();
 /// ```
+///
+/// For a builder-style API, see [`init_poseidon2_16_with`].
 pub fn init_poseidon2_16(perm: Poseidon2KoalaBear<16>) -> Result<(), Poseidon2InitError> {
     POSEIDON2_16
         .set(perm)
         .map_err(|_| Poseidon2InitError::AlreadyInitialized { width: 16 })
 }
 
-/// Initialize the width-16 Poseidon2 permutation using a constructor.
+/// Initialize the width-16 Poseidon2 permutation using a builder.
 ///
-/// The constructor will only be called if the permutation has not been initialized yet.
+/// The builder is only called if the permutation has not been initialized yet.
+/// This function is intended for single-threaded initialization at program startup.
 ///
 /// # Errors
 /// Returns `Poseidon2InitError::AlreadyInitialized { width: 16 }` if the permutation was already
@@ -118,7 +122,6 @@ where
     if POSEIDON2_16.get().is_some() {
         return Err(Poseidon2InitError::AlreadyInitialized { width: 16 });
     }
-
     init_poseidon2_16(builder())
 }
 


### PR DESCRIPTION
**Motivation**

- Downstream projects sometimes need to use a different Poseidon2 constant set (e.g. spec/test-vector aligned constants) than the default provided by [p3_koala_bear::default_koalabear_poseidon2_{16,24}](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Today, the only option is vendoring/patching this crate to swap the internal Poseidon2 permutation(s), which hurts reproducibility and maintainability.

**What this PR does**

- Adds opt-in “initialize once” APIs to provide custom Poseidon2 permutations for widths 24 and 16:
  - [init_poseidon2_24(perm)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) / [init_poseidon2_16(perm)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
  - [init_poseidon2_24_with(|| perm)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) / [init_poseidon2_16_with(|| perm)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Keeps existing behavior as default: if not initialized, the crate continues to lazily use the Plonky3 defaults.
- Returns [Poseidon2InitError::AlreadyInitialized { width }](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) if initialization happens after the permutation has already been used/initialized.

**Why builder-based APIs**

- Avoids forcing callers to construct and pass large constant arrays through public APIs.
- Lets downstream build permutations however they like (from constants, config files, feature-gated code, etc.) while keeping this crate’s surface area small.

**Tests**

- Adds unit tests covering:
  - Calling init after the permutation is initialized returns [AlreadyInitialized](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
  - Builder is not executed when already initialized