### PR TITLE
leanMultisig Serializeable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub const TWEAK_SEPARATOR_FOR_CHAIN_HASH: u8 = 0x00;
 type F = KoalaBear;
 pub(crate) type PackedF = <F as Field>::Packing;
 
-pub(crate) mod array;
+pub mod array;
 pub(crate) mod hypercube;
 pub mod inc_encoding;
 pub mod serialization;


### PR DESCRIPTION
- Expose `FieldArray` to leanMultisig, needed for implementing `Serializeable` trait.
- https://github.com/leanEthereum/leanMultisig/pull/130