### PR TITLE
get_public_key

### DIFF
--- a/src/signature.rs
+++ b/src/signature.rs
@@ -203,6 +203,15 @@ pub trait SignatureScheme {
         message: &[u8; MESSAGE_LENGTH],
         sig: &Self::Signature,
     ) -> bool;
+
+    /// Get public key corresponding to given secret key.
+    ///
+    /// ### Parameters
+    /// * `sk`: A reference to the secret key.
+    ///
+    /// ### Returns
+    /// Public key corresponding to given secret key.
+    fn get_public_key(sk: &Self::SecretKey) -> Self::PublicKey;
 }
 
 pub mod generalized_xmss;

--- a/src/signature/generalized_xmss.rs
+++ b/src/signature/generalized_xmss.rs
@@ -1003,6 +1003,13 @@ where
             &sig.path,
         )
     }
+
+    fn get_public_key(sk: &Self::SecretKey) -> Self::PublicKey {
+        Self::PublicKey {
+            root: sk.top_tree.root(),
+            parameter: sk.parameter,
+        }
+    }
 }
 
 impl<TH: TweakableHash> Encode for GeneralizedXMSSPublicKey<TH> {

--- a/src/signature/generalized_xmss.rs
+++ b/src/signature/generalized_xmss.rs
@@ -826,10 +826,8 @@ where
             &parameter,
             roots_of_bottom_trees,
         );
-        let root = top_tree.root();
 
         // assemble public key and secret key
-        let pk = GeneralizedXMSSPublicKey { root, parameter };
         let sk = GeneralizedXMSSSecretKey {
             prf_key,
             parameter,
@@ -841,6 +839,7 @@ where
             right_bottom_tree,
             _encoding_type: PhantomData,
         };
+        let pk = Self::get_public_key(&sk);
 
         (pk, sk)
     }


### PR DESCRIPTION
Add `SignatureScheme::get_public_key(&SecretKey) -> PublicKey` function.
Allows checking secret/public key files consistency and deriving public key file from secret key file.